### PR TITLE
Liblights fix

### DIFF
--- a/liblights/Android.mk
+++ b/liblights/Android.mk
@@ -28,7 +28,9 @@ LOCAL_MODULE := lights.hi6250
 
 ifneq ($(TARGET_PRODUCT),omni_hi6250)
 ifneq ($(TARGET_PRODUCT),aosp_hi6250)
+ifneq ($(TARGET_PRODUCT),pa_hi6250)
 LOCAL_CFLAGS += -DLEDSMODE
+endif
 endif
 endif
 

--- a/liblights/lights.c
+++ b/liblights/lights.c
@@ -90,154 +90,153 @@ static int write_int(char const *path, int value)
 
 static int rgb_to_brightness(struct light_state_t const * state) {
 
-    unsigned int brightness = ((77*((state->color>>16)&0x00ff))
-    		+ (150*((state->color>>8)&0x00ff)) + (29*(state->color&0x00ff))) >> 8;
-    return brightness;
+	unsigned int brightness = ((77 * ((state->color >> 16) & 0x00ff))
+	                           + (150 * ((state->color >> 8) & 0x00ff)) + (29 * (state->color & 0x00ff))) >> 8;
+	return brightness;
 
 }
 
 /** Set LCD backlight **/
 static int set_light_backlight(struct light_device_t *dev, struct light_state_t const *state)
 {
-    pthread_mutex_lock(&g_lock);
-    int err = write_int(BACKLIGHT_FILE, rgb_to_brightness(state));
-    pthread_mutex_unlock(&g_lock);
-    return err;
+	pthread_mutex_lock(&g_lock);
+	int err = write_int(BACKLIGHT_FILE, rgb_to_brightness(state));
+	pthread_mutex_unlock(&g_lock);
+	return err;
 }
 
 static void stop_blink(void) {
-    write_int(RED_DELAYON_FILE, 0);
-    write_int(RED_DELAYOFF_FILE, 0);
-    write_int(GREEN_DELAYON_FILE, 0);
-    write_int(GREEN_DELAYOFF_FILE, 0);
-    write_int(BLUE_DELAYON_FILE, 0);
-    write_int(BLUE_DELAYOFF_FILE, 0);
+	write_int(RED_DELAYON_FILE, 0);
+	write_int(RED_DELAYOFF_FILE, 0);
+	write_int(GREEN_DELAYON_FILE, 0);
+	write_int(GREEN_DELAYOFF_FILE, 0);
+	write_int(BLUE_DELAYON_FILE, 0);
+	write_int(BLUE_DELAYOFF_FILE, 0);
 }
 
 static void int_to_argb(int color, int argb[]) {
-    char scolor[255];
-    char alpha[3], red[3], green[3], blue[3];
-    sprintf(scolor, "%x",color);
+	char scolor[255];
+	char alpha[3], red[3], green[3], blue[3];
+	sprintf(scolor, "%x", color);
 #ifdef DEBUG
-    ALOGD("color=%s",scolor);
+	ALOGD("color=%s", scolor);
 #endif
-    strncpy(alpha,scolor,2);
-    strncpy(red, scolor + 2,2);
-    strncpy(green, scolor + 4,2);
-    strncpy(blue, scolor + 6,2);
-    alpha[2] = red[2] = green[2] = blue[2] = '\0';
+	strncpy(alpha, scolor, 2);
+	strncpy(red, scolor + 2, 2);
+	strncpy(green, scolor + 4, 2);
+	strncpy(blue, scolor + 6, 2);
+	alpha[2] = red[2] = green[2] = blue[2] = '\0';
 #ifdef DEBUG
-    ALOGD("alpha=%s red=%s green=%s blue=%s",alpha,red,green,blue);
+	ALOGD("alpha=%s red=%s green=%s blue=%s", alpha, red, green, blue);
 #endif
-    argb[0] = (int)strtol(alpha,NULL,16);
-    argb[1] = (int)strtol(red,NULL,16);
-    argb[2] = (int)strtol(green,NULL,16);
-    argb[3] = (int)strtol(blue,NULL,16);
+	argb[0] = (int)strtol(alpha, NULL, 16);
+	argb[1] = (int)strtol(red, NULL, 16);
+	argb[2] = (int)strtol(green, NULL, 16);
+	argb[3] = (int)strtol(blue, NULL, 16);
 
 }
 
 static void set_light_color(int color) {
 
-    int argb[4];
-    stop_blink();
+	int argb[4];
+	stop_blink();
 
-    int_to_argb(color, argb);
+	int_to_argb(color, argb);
 
-    write_int(RED_BRIGHTNESS_FILE,argb[1]);
-    write_int(GREEN_BRIGHTNESS_FILE,argb[2]);
-    write_int(BLUE_BRIGHTNESS_FILE,argb[3]);
+	write_int(RED_BRIGHTNESS_FILE, argb[1]);
+	write_int(GREEN_BRIGHTNESS_FILE, argb[2]);
+	write_int(BLUE_BRIGHTNESS_FILE, argb[3]);
 
 }
 
 static void set_blink(struct light_state_t const* state) {
-    char scolor[255];
-    char alpha[3], red[3], green[3], blue[3];
-    int ialpha,ired,igreen,iblue;
-    sprintf(scolor, "%x",state->color);
+	char scolor[255];
+	char alpha[3], red[3], green[3], blue[3];
+	int ialpha, ired, igreen, iblue;
+	sprintf(scolor, "%x", state->color);
 #ifdef DEBUG
-    ALOGD("color=%s",scolor);
+	ALOGD("color=%s", scolor);
 #endif
-    strncpy(alpha,scolor,2);
-    strncpy(red, scolor + 2,2);
-    strncpy(green, scolor + 4,2);
-    strncpy(blue, scolor + 6,2);
-    alpha[2] = red[2] = green[2] = blue[2] = '\0';
+	strncpy(alpha, scolor, 2);
+	strncpy(red, scolor + 2, 2);
+	strncpy(green, scolor + 4, 2);
+	strncpy(blue, scolor + 6, 2);
+	alpha[2] = red[2] = green[2] = blue[2] = '\0';
 #ifdef DEBUG
-    ALOGD("alpha=%s red=%s green=%s blue=%s",alpha,red,green,blue);
+	ALOGD("alpha=%s red=%s green=%s blue=%s", alpha, red, green, blue);
 #endif
-    ired = strtol(red,NULL,16);
-    igreen = strtol(green,NULL,16);
-    iblue = strtol(blue,NULL,16);
+	ired = strtol(red, NULL, 16);
+	igreen = strtol(green, NULL, 16);
+	iblue = strtol(blue, NULL, 16);
 
 #ifdef DEBUG
+	ALOGD("flashMode=%d flashOnMS=%d flashOffMS=%d brightnessMode=%d",
+	      state->flashMode,
+	      state->flashOnMS,
+	      state->flashOffMS,
+	      state->brightnessMode);
 #ifdef LEDSMODE
-    ALOGD("flashMode=%d flashOnMS=%d flashOffMS=%d brightnessMode=%d ledsModes=%d",
-				state->flashMode,
-				state->flashOnMS,
-				state->flashOffMS,
-				state->brightnessMode,
-				state->ledsModes);
+	ALOGD("ledsModes=%d", state->ledsModes);
 #endif
-#endif 
-    stop_blink();
-    if(!state->flashMode) return;
+#endif
+	stop_blink();
+	if (!state->flashMode) return;
 
-    if(ired) {
-	write_int(RED_DELAYON_FILE, state->flashOnMS);
-	write_int(RED_DELAYOFF_FILE, state->flashOffMS);
-    }
-    if(igreen) {
-	write_int(GREEN_DELAYON_FILE, state->flashOnMS);
-	write_int(GREEN_DELAYOFF_FILE, state->flashOffMS);
-    }
-    if(iblue) {
-	write_int(BLUE_DELAYON_FILE, state->flashOnMS);
-	write_int(BLUE_DELAYOFF_FILE, state->flashOffMS);
-    }
+	if (ired) {
+		write_int(RED_DELAYON_FILE, state->flashOnMS);
+		write_int(RED_DELAYOFF_FILE, state->flashOffMS);
+	}
+	if (igreen) {
+		write_int(GREEN_DELAYON_FILE, state->flashOnMS);
+		write_int(GREEN_DELAYOFF_FILE, state->flashOffMS);
+	}
+	if (iblue) {
+		write_int(BLUE_DELAYON_FILE, state->flashOnMS);
+		write_int(BLUE_DELAYOFF_FILE, state->flashOffMS);
+	}
 }
 
 
 
 static int set_light_notifications(struct light_device_t* dev, struct light_state_t const* state)
 {
-    int err = 0; 
-    pthread_mutex_lock(&g_lock);
-    last_noti_color = state->color;
-    /* reset before changing */
-    set_light_color(0xff000000);
-    if(state->color == 0xff000000)
-	set_light_color(last_battery_color);
-    else
-	set_light_color(property_get_int32(NOTIFICATION,state->color));
-    set_blink(state);
-    pthread_mutex_unlock(&g_lock);
-    return err;
+	int err = 0;
+	pthread_mutex_lock(&g_lock);
+	last_noti_color = state->color;
+	/* reset before changing */
+	set_light_color(0xff000000);
+	if (state->color == 0xff000000 || !state->color)
+		set_light_color(last_battery_color);
+	else
+		set_light_color(property_get_int32(NOTIFICATION, state->color));
+	set_blink(state);
+	pthread_mutex_unlock(&g_lock);
+	return err;
 }
 
 static int set_light_battery(struct light_device_t* dev, struct light_state_t const* state)
 {
-    int err = 0;
-    int argb[4];
-    int color = state->color;
-    pthread_mutex_lock(&g_lock);
-    last_battery_color = state->color;
-    if(last_noti_color == 0xff000000) {
-        int_to_argb(color,argb);
-	/* Yellow charging between 25% and 90% */
-	if(argb[1] == 0xff && argb[2] == 0xff && argb[3] == 0x00)
-	    color = property_get_int64(CHARGING_PROP,color);
-	/* Red below 25 % */
-	else if(argb[1] == 0xff && argb[2] == 0x00 && argb[3] == 0x00)
-	    color = property_get_int64(LOWPOWER_PROP,color);
-	/* Green 90% or above */
-	else if(argb[1] == 0x00 && argb[2] == 0xff && argb[3] == 0x00)
-	    color = property_get_int64(FULLPOWER_PROP,color);
-
-	set_light_color(color);
-	set_blink(state);
-    }
-    pthread_mutex_unlock(&g_lock);
-    return err;
+	int err = 0;
+	int argb[4];
+	int color = state->color;
+	pthread_mutex_lock(&g_lock);
+	last_battery_color = state->color;
+	if (last_noti_color == 0xff000000 || !last_noti_color) {
+		int_to_argb(color, argb);
+		/* Yellow charging between 25% and 90% */
+		if (argb[1] == 0xff && argb[2] == 0xff && argb[3] == 0x00)
+			color = property_get_int64(CHARGING_PROP, color);
+		/* Red below 25 % */
+		else if (argb[1] == 0xff && argb[2] == 0x00 && argb[3] == 0x00)
+			color = property_get_int64(LOWPOWER_PROP, color);
+		/* Green 90% or above */
+		else if (argb[1] == 0x00 && argb[2] == 0xff && argb[3] == 0x00)
+			color = property_get_int64(FULLPOWER_PROP, color);
+		set_light_color(color);
+		set_blink(state);
+	}
+	pthread_mutex_unlock(&g_lock);
+	return err;
 }
 
 /** Close the lights device */
@@ -252,27 +251,27 @@ static int close_lights(struct light_device_t *dev)
 static int open_lights(const struct hw_module_t *module, char const *name, struct hw_device_t **device)
 {
 
-	if(property_get_bool(STOCK_PROP, 0)) {
-	    ALOGI("%s is set. Loading Stock lights HAL",STOCK_PROP);
-	    if(!load_stock_lights("/system/lib64/hw/lights.default.so", &module)) {
-		return module->methods->open(module,name,device);
-	    } else {
-		ALOGE("%s is set but could not load Stock lights HAL!", STOCK_PROP);
-		property_set(STOCK_PROP, "false");
-	    }
+	if (property_get_bool(STOCK_PROP, 0)) {
+		ALOGI("%s is set. Loading Stock lights HAL", STOCK_PROP);
+		if (!load_stock_lights("/system/lib64/hw/lights.default.so", &module)) {
+			return module->methods->open(module, name, device);
+		} else {
+			ALOGE("%s is set but could not load Stock lights HAL!", STOCK_PROP);
+			property_set(STOCK_PROP, "false");
+		}
 	}
 
 	pthread_t lighting_poll_thread;
 
 	int (*set_light) (struct light_device_t *dev,
-			  struct light_state_t const *state);
+	                  struct light_state_t const * state);
 
 	if (0 == strcmp(LIGHT_ID_BACKLIGHT, name))
 		set_light = set_light_backlight;
 	else if (0 == strcmp(LIGHT_ID_NOTIFICATIONS, name))
-        	set_light = set_light_notifications;
+		set_light = set_light_notifications;
 	else if (0 == strcmp(LIGHT_ID_BATTERY, name))
-        	set_light = set_light_battery;
+		set_light = set_light_battery;
 	else
 		return -EINVAL;
 


### PR DESCRIPTION
* Reindented file
* When ROM sets the LED color, for example you get notification and it flashes red. After dismissing the notification, ROM sets LED color to "0" and not "0xff000000". Because of the check for "0xff000000", it fails to change the LED color on following notifications or battery state changes.
* The ledsmode debug flag is only in CM, but the other info is good for debug, so I have separated it.