### PR TITLE
Audio recording issue + logs (dmesg & logcat)

### DIFF
--- a/libhuawei_init/huawei_init.cpp
+++ b/libhuawei_init/huawei_init.cpp
@@ -91,18 +91,10 @@ void vendor_load_default_properties() {
     /* All Prague needs this */
     } else if(!strncmp(model, "PRA", 3)) {
 	set_property(BOARDID_PRODUCT_PROP, "61285");
+	set_property("media.settings.xml", "/etc/media_profiles_was.xml");
     /* All Warsaw needs this */
     } else if(!strncmp(model, "WAS", 3)) {
 	set_property(BOARDID_PRODUCT_PROP, "61457");
-	/* Meticulus:
-	 * For some odd reason the camera reports that it can
-	 * not set a preview frame rato of 30. A frame rate of 25
-	 * works but mysteriously, the media_profiles.xml which
-	 * defines what framerates are supported all show 30. So
-	 * I modified it to 25 on the rear camera and specify
-	 * this prop to load this one instead of the one at
-	 * /vendor/etc
-	 */
 	set_property("media.settings.xml", "/etc/media_profiles_was.xml");
     /* All Honor 5c/Honor 7 lite needs this */
     } else if(!strncmp(model, "NEM", 3) || !strncmp(model, "NMO", 3)) {

--- a/vendor_symlink/Android.mk
+++ b/vendor_symlink/Android.mk
@@ -670,7 +670,7 @@ hw := \
     vibrator.default.so
 
 hw64 := \
-    activity_reconition.default.so \
+    activity_recognition.default.so \
     audio.primary.default.so \
     audio.primary.hisi.so \
     audio.r_submix.default.so \


### PR DESCRIPTION
Hi
I've created this PR to inform you about an issue that raised 
i have a p8 lite 2017, and i've installed LOS from haky 86, he based all of its work on your sources

the issue is the following:
- sometimes whatsapp voice notes doesnt get recorder at all OR they get recorded with a very strange crackling sound (all get distorted, cant hear anything apart from BZZZ or GRZZZ)
- sometimes in call mic doesnt work, and need a restart to fix it 

I've got logs here:
[dmesg](https://mega.nz/#!qt0hTDbQ!flY4pxyZQSS_NN8mW9s9N6QczssPn_bu7mS5jxpX2HE)
[logcat](https://mega.nz/#!voFCDAjQ!Tx9j0wY60J0oKJViRr5tEErN0nvguupQrbx8wOrgiVU)

i've also talked with another dev, he said that he suspects Audio Policy for those two things:
(logcat)
`02-15 21:00:35.693 W/AudioTrack(1756): AUDIO_OUTPUT_FLAG_FAST denied by client; transfer 4, track 8000 Hz, output 48000 Hz`

(dmesg)
`[ 3698.075958s][pid:10569,cpu5,AudioIn_B6]hifi_misc [I][121178552]:hifi_misc_msg_info:181: MSG: ID_AP_AUDIO_CMD_SET_SOURCE_CMD.
[ 3698.079467s][pid:10568,cpu0,FastCapture]hi6210snd[I]:hi6210_pcm_notify_hw_params:817: rate is 48000
[ 3698.096862s][pid:10568,cpu3,FastCapture]hifi_misc [I][121179237]:hifi_misc_msg_info:181: MSG: ID_AP_AUDIO_CMD_SET_SOURCE_CMD.
[ 3698.097076s][pid:10568,cpu3,FastCapture]hi6210snd[I]:hi6210_pcm_trigger:1095: device 0 mode 1 trigger 1`

hope this can help you to further address the issue and fix it!! 

/* EDIT */
More logs while having audio issues
[logs](https://mega.nz/#!rg1D0CxC!o5BnFoodMXchEurSANK4LvJJ9TZU0D39v4b9idSVlFE)
Cheers
Federico